### PR TITLE
Fix internal link in index.rst

### DIFF
--- a/api-client-python/index.rst
+++ b/api-client-python/index.rst
@@ -12,7 +12,7 @@ provides a simple genome browser that pulls data from the Genomics API.
 
 
 The python client does not currently use 
-`Google's python client library <https://devsite.googleplex.com/api-client-library/python/>`_. 
+`Google's python client library <https://developers.google.com/api-client-library/python/>`_. 
 If you want to use the client library, the
 `method documentation <https://developers.google.com/resources/api-libraries/documentation/genomics/v1beta2/python/latest/>`_ 
 for genomics can be very useful.


### PR DESCRIPTION
Change the internal link to the Google Python client library to an equivalent external one.
