### PR TITLE
One-click enable all APIs needed by Dataflow.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -134,6 +134,8 @@ rst_epilog = """
 .. _Picard: http://broadinstitute.github.io/picard/
 .. _GATK: https://www.broadinstitute.org/gatk/
 
+.. _Quality Control using Google Genomics: https://github.com/googlegenomics/codelabs/tree/master/R/PlatinumGenomes-QC
+
 """
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/source/includes/dataflow_on_gce_setup.rst
+++ b/docs/source/includes/dataflow_on_gce_setup.rst
@@ -14,9 +14,9 @@
 
       .. code-block:: shell
 
+        curl -O -L https://github.com/googlegenomics/dataflow-java/raw/master/google-genomics-dataflow.jar
         sudo apt-get update
         sudo apt-get install --assume-yes openjdk-7-jdk maven
-        curl -O -L https://github.com/googlegenomics/dataflow-java/raw/master/google-genomics-dataflow.jar
         sudo update-alternatives --config java
 
       (3) Run the following command from your local machine to copy the ``client_secrets.json`` to the Compute Engine instance.  If you do not already have this file, see the `sign up instructions <https://cloud.google.com/genomics/install-genomics-tools#authenticate>`_ to obtain it.
@@ -25,6 +25,6 @@
 
         gcloud compute copy-files ~/googlegenomics/dataflow-java/client_secrets.json INSTANCE-NAME:~/
 
-      (4) If you have not already done so, enable the Google Cloud Platform APIs used by `Google Cloud Dataflow`_.  See the `Core Cloud Platform Setup Steps <https://cloud.google.com/dataflow/getting-started#Core>`_ for the list of APIs to enable.
+      (4) If you have not already done so, click `here <https://console.developers.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_component,storage_api,bigquery,pubsub,datastore&_ga=1.38537760.2067798380.1406160784>`_ to enable the Google Cloud Platform APIs used by `Google Cloud Dataflow`_.
 
     *Tip:* Add option ``--noLaunchBrowser`` your dataflow command lines so that the authorization flow prints a URL to be copied instead of launching a web browser.

--- a/docs/source/includes/dataflow_setup.rst
+++ b/docs/source/includes/dataflow_setup.rst
@@ -18,4 +18,4 @@
 
       (2) Copy your ``client_secrets.json`` to same directory as the Jar.  If you do not already have this file, see the `sign up instructions <https://cloud.google.com/genomics/install-genomics-tools#authenticate>`_ to obtain it.
 
-      (3) If you have not already done so, enable the Google Cloud Platform APIs used by `Google Cloud Dataflow`_.  See the `Core Cloud Platform Setup Steps <https://cloud.google.com/dataflow/getting-started#Core>`_ for the list of APIs to enable.
+      (3) If you have not already done so, click `here <https://console.developers.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_component,storage_api,bigquery,pubsub,datastore&_ga=1.38537760.2067798380.1406160784>`_ to enable the Google Cloud Platform APIs used by `Google Cloud Dataflow`_.

--- a/docs/source/use_cases/compute_principal_coordinate_analysis/2-way-pca.rst
+++ b/docs/source/use_cases/compute_principal_coordinate_analysis/2-way-pca.rst
@@ -1,0 +1,60 @@
+Compute Principal Coordinate Analysis on the Intersection of Two Datasets
+=========================================================================
+
+.. toctree::
+   :maxdepth: 2
+
+.. contents::
+
+`Principal Coordinate Analysis <http://occamstypewriter.org/boboh/2012/01/17/pca_and_pcoa_explained/>`_
+counts the number of variants two samples have in common.  These counts are then placed into an
+``NxN`` matrix where ``N`` is the number of samples in the dataset.  The matrix is centered,
+scaled, and then the first two principal components are computed for each invididual.
+
+In the two-way version, the variants shared between two datasets are used to compute PCA among the individuals in both datasets.  This can be useful, for example, as an ethnicity check when comparing a dataset to 1,000 Genomes.  See codelab `Quality Control using Google Genomics`_ for an example of this.
+
+An `Apache Spark`_ implementation is available.
+
+Setup
+-----
+
+.. include:: ../../includes/spark_setup.rst
+
+Run the job
+-----------
+
+The following command will run a two-way PCA over the BRCA1 region within the `Platinum Genomes`_ dataset and the `1,000 Genomes`_ phase 1 variants.
+
+.. code-block:: shell
+
+  spark-submit \
+    --class com.google.cloud.genomics.spark.examples.VariantsPcaDriver \
+    --conf spark.shuffle.spill=true \
+    --master spark://hadoop-m:7077 \
+    /PATH/TO/googlegenomics-spark-examples-assembly-1.0.jar \
+    --client-secrets /PATH/TO/YOUR/client_secrets.json \
+    --variant-set-id 10473108253681171589 3049512673186936334 \
+    --references chr17:41196311:41277499 \
+    --output-path gs://YOUR-BUCKET/output/two-way-brca1-pca.tsv
+
+The above command line runs the job over a small portion of the genome, only taking a few minutes.  If modified to run over a larger portion of the genome or the entire genome, it may take a few hours depending upon how many machines are in the Spark cluster.
+
+To run this job over the entire genome:
+
+* Add ``--num-reduce-partitions #`` to be equal to the number of cores in your cluster.
+* Use ``--all-references`` instead of ``--references chr17:41196311:41277499`` to run over the entire genome.
+* To run the job on a different dataset, change the variant set id for the ``--variant-set-id`` id parameter.
+
+Additional details
+------------------
+
+.. include:: ../../includes/spark_details.rst
+
+Gather the results into a single file
+-------------------------------------
+
+.. code-block:: shell
+
+  gsutil cat gs://YOUR-BUCKET/output/two-way-brca1-pca.tsv* \
+    | sort > two-way-brca1-pca.tsv
+

--- a/docs/source/use_cases/discover_public_data/google_genomics_public_data.rst
+++ b/docs/source/use_cases/discover_public_data/google_genomics_public_data.rst
@@ -7,6 +7,9 @@ Google Genomics Public Data
 For public data hosted by Google Genomics such as:
 
 * the 1,000 Genomes reads and Phase 1 and Phase 3 variants
+
+  * Including a full mirror of http://ftp-trace.ncbi.nih.gov/1000genomes/ftp/ in Google Cloud Storage `gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/ <https://console.developers.google.com/storage/browser/genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/>`_.
+  
 * Illumina Platinum Genomes reads and variants
 * Reference Genomes such as GRCh37, GRCh37lite, GRCh38, hg19, hs37d5
 

--- a/docs/source/use_cases/perform_quality_control_checks/index.rst
+++ b/docs/source/use_cases/perform_quality_control_checks/index.rst
@@ -1,7 +1,7 @@
 Perform Quality Control Checks
 ==============================
 
-There are a collection of quality control checks for variants documented in codelab `Quality Control using Google Genomics <https://github.com/googlegenomics/codelabs/tree/master/R/PlatinumGenomes-QC>`_.
+There are a collection of quality control checks for variants documented in codelab `Quality Control using Google Genomics`_.
 
 To make use of this upon your own data:
 


### PR DESCRIPTION
Also added skeleton content for 2-way PCA but left it unlinked from the TOC pending: 
 1. the merge of https://github.com/elmer-garduno/spark-examples/tree/multiple_dataset_pca onto https://github.com/googlegenomics/spark-examples
 2. the update to https://github.com/googlegenomics/codelabs/blob/master/R/PlatinumGenomes-QC/Sample-Level-QC.md#ethnicity-inference