### PR TITLE
Update dataflow instructions to runnable jar now available in Maven Central.

### DIFF
--- a/docs/source/includes/dataflow_details.rst
+++ b/docs/source/includes/dataflow_details.rst
@@ -3,7 +3,7 @@ the pipeline class name below to match the one you would like to run.
 
 .. code-block:: shell
 
-  java -cp google-genomics-dataflow*.jar \
+  java -cp google-genomics-dataflow*runnable.jar \
     com.google.cloud.genomics.dataflow.pipelines.VariantSimilarity --help
 
 See the source code for implementation details: https://github.com/googlegenomics/dataflow-java

--- a/docs/source/includes/dataflow_on_gce_setup.rst
+++ b/docs/source/includes/dataflow_on_gce_setup.rst
@@ -24,7 +24,7 @@
 
         gcloud compute copy-files /PATH/TO/client_secrets.json INSTANCE-NAME:~/
 
-      (3) Run the following commands on the Compute Engine instance to install `Java 7 <http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html>`_.
+      (5) Run the following commands on the Compute Engine instance to install `Java 7 <http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html>`_.
 
       .. code-block:: shell
 

--- a/docs/source/includes/dataflow_on_gce_setup.rst
+++ b/docs/source/includes/dataflow_on_gce_setup.rst
@@ -8,7 +8,7 @@
 
       If you do not have Java on your local machine, you can set up Java 7 on a `Google Compute Engine`_ instance.  The following setup instructions will allow you to *launch* Dataflow jobs from a Compute Engine instance:
 
-      (1) If you have not already done so, click `here <https://console.developers.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_component,storage_api,bigquery,pubsub,datastore&_ga=1.38537760.2067798380.1406160784>`_ to enable the Google Cloud Platform APIs used by `Google Cloud Dataflow`_.
+      (1) If you have not already enabled the Google Cloud Platform APIs used by `Google Cloud Dataflow`_, click `here <https://console.developers.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_component,storage_api,bigquery,pubsub,datastore&_ga=1.38537760.2067798380.1406160784>`_ to do so.
 
       (2) Use the `Google Developers Console`_ to spin up a `Google Compute Engine`_ instance and ssh into it.  If you have not done this before, see the `step-by-step instructions <https://cloud.google.com/compute/docs/quickstart-developer-console>`_.
 

--- a/docs/source/includes/dataflow_on_gce_setup.rst
+++ b/docs/source/includes/dataflow_on_gce_setup.rst
@@ -8,23 +8,28 @@
 
       If you do not have Java on your local machine, you can set up Java 7 on a `Google Compute Engine`_ instance.  The following setup instructions will allow you to *launch* Dataflow jobs from a Compute Engine instance:
 
-      (1) Use the `Google Developers Console`_ to spin up a `Google Compute Engine`_ instance and ssh into it.  If you have not done this before, see the `step-by-step instructions <https://cloud.google.com/compute/docs/quickstart-developer-console>`_.
+      (1) If you have not already done so, click `here <https://console.developers.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_component,storage_api,bigquery,pubsub,datastore&_ga=1.38537760.2067798380.1406160784>`_ to enable the Google Cloud Platform APIs used by `Google Cloud Dataflow`_.
 
-      (2) Run the following commands on the Compute Engine instance to install `Java 7 <http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html>`_ and copy the Jar.
+      (2) Use the `Google Developers Console`_ to spin up a `Google Compute Engine`_ instance and ssh into it.  If you have not done this before, see the `step-by-step instructions <https://cloud.google.com/compute/docs/quickstart-developer-console>`_.
+
+      (3) Run the following command from your local machine to copy the **runnable** jar to the Compute Engine instance.  You can download the latest GoogleGenomics dataflow **runnable** jar from the `Maven Central Repository <https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.google.cloud.genomics%22%20AND%20a%3A%22google-genomics-dataflow%22>`_.
 
       .. code-block:: shell
 
-        curl -O -L https://github.com/googlegenomics/dataflow-java/raw/master/google-genomics-dataflow.jar
+        gcloud compute copy-files /PATH/TO/google-genomics-dataflow*runnable.jar INSTANCE-NAME:~/
+
+      (4) Run the following command from your local machine to copy the ``client_secrets.json`` to the Compute Engine instance.  If you do not already have ``client_secrets.json``, see the `sign up instructions <https://cloud.google.com/genomics/install-genomics-tools#authenticate>`_ to obtain it.
+
+      .. code-block:: shell
+
+        gcloud compute copy-files /PATH/TO/client_secrets.json INSTANCE-NAME:~/
+
+      (3) Run the following commands on the Compute Engine instance to install `Java 7 <http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html>`_.
+
+      .. code-block:: shell
+
         sudo apt-get update
         sudo apt-get install --assume-yes openjdk-7-jdk maven
         sudo update-alternatives --config java
-
-      (3) Run the following command from your local machine to copy the ``client_secrets.json`` to the Compute Engine instance.  If you do not already have this file, see the `sign up instructions <https://cloud.google.com/genomics/install-genomics-tools#authenticate>`_ to obtain it.
-
-      .. code-block:: shell
-
-        gcloud compute copy-files ~/googlegenomics/dataflow-java/client_secrets.json INSTANCE-NAME:~/
-
-      (4) If you have not already done so, click `here <https://console.developers.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_component,storage_api,bigquery,pubsub,datastore&_ga=1.38537760.2067798380.1406160784>`_ to enable the Google Cloud Platform APIs used by `Google Cloud Dataflow`_.
 
     *Tip:* Add option ``--noLaunchBrowser`` your dataflow command lines so that the authorization flow prints a URL to be copied instead of launching a web browser.

--- a/docs/source/includes/dataflow_setup.rst
+++ b/docs/source/includes/dataflow_setup.rst
@@ -12,6 +12,6 @@
 
       (2) Copy your ``client_secrets.json`` to same directory as the Jar.  If you do not already have this file, see the `sign up instructions <https://cloud.google.com/genomics/install-genomics-tools#authenticate>`_ to obtain it.
 
-      (3) If you have not already done so, click `here <https://console.developers.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_component,storage_api,bigquery,pubsub,datastore&_ga=1.38537760.2067798380.1406160784>`_ to enable the Google Cloud Platform APIs used by `Google Cloud Dataflow`_.
+      (3)  If you have not already enabled the Google Cloud Platform APIs used by `Google Cloud Dataflow`_, click `here <https://console.developers.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_component,storage_api,bigquery,pubsub,datastore&_ga=1.38537760.2067798380.1406160784>`_ to do so.
 
       (4) If you have not already done so, follow the instructions to `install gcloud`_.

--- a/docs/source/includes/dataflow_setup.rst
+++ b/docs/source/includes/dataflow_setup.rst
@@ -8,13 +8,7 @@
 
       Most users *kick off* Dataflow jobs from their local machine.  This is unrelated to where the job itself actually runs (which is controlled by the ``--runner`` parameter).  Either way, `Java 7 <http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html>`_ is needed to run the Jar that kicks off the job.
 
-      (1) Click to download the `GoogleGenomics Dataflow Jar <https://github.com/googlegenomics/dataflow-java/blob/master/google-genomics-dataflow.jar>`_ or use ``curl``:
-
-    .. code-block:: shell
-
-      curl -O -L https://github.com/googlegenomics/dataflow-java/raw/master/google-genomics-dataflow.jar
-
-    .. container:: content
+      (1) Download the latest GoogleGenomics dataflow **runnable** jar from the `Maven Central Repository <https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.google.cloud.genomics%22%20AND%20a%3A%22google-genomics-dataflow%22>`_.
 
       (2) Copy your ``client_secrets.json`` to same directory as the Jar.  If you do not already have this file, see the `sign up instructions <https://cloud.google.com/genomics/install-genomics-tools#authenticate>`_ to obtain it.
 

--- a/docs/source/use_cases/analyze_reads/calculate_coverage.rst
+++ b/docs/source/use_cases/analyze_reads/calculate_coverage.rst
@@ -55,7 +55,7 @@ dataset id:
 
 .. code-block:: shell
 
-  java -cp target/google-genomics-dataflow*.jar \
+  java -cp /PATH/TO/google-genomics-dataflow*runnable.jar \
     com.google.cloud.genomics.dataflow.pipelines.CalculateCoverage \
     --project=YOUR-GOOGLE-CLOUD-PLATFORM-PROJECT-ID \
     --stagingLocation=gs://YOUR-BUCKET/dataflow-staging \
@@ -154,7 +154,7 @@ fewer read group sets then the default requirement of 11:
 
 .. code-block:: shell
 
-  java -cp /PATH/TO/google-genomics-dataflow*.jar \
+  java -cp /PATH/TO/google-genomics-dataflow*runnable.jar \
     com.google.cloud.genomics.dataflow.pipelines.CalculateCoverage \
     --project=YOUR-GOOGLE-CLOUD-PLATFORM-PROJECT-ID \
     --stagingLocation=gs://YOUR-BUCKET/dataflow-staging \

--- a/docs/source/use_cases/analyze_reads/count_reads.rst
+++ b/docs/source/use_cases/analyze_reads/count_reads.rst
@@ -30,7 +30,7 @@ specifically those in the BRCA1 region for sample NA12877 within the `Platinum G
 
 .. code-block:: shell
 
-  java -cp /PATH/TO/google-genomics-dataflow*.jar \
+  java -cp /PATH/TO/google-genomics-dataflow*runnable.jar \
     com.google.cloud.genomics.dataflow.pipelines.CountReads \
     --project=YOUR-GOOGLE-CLOUD-PLATFORM-PROJECT-ID \
     --stagingLocation=gs://YOUR-BUCKET/dataflow-staging \
@@ -43,7 +43,7 @@ The following command will count those same reads but from the `Google Genomics 
 
 .. code-block:: shell
 
-  java -cp /PATH/TO/google-genomics-dataflow*.jar \
+  java -cp /PATH/TO/google-genomics-dataflow*runnable.jar \
     com.google.cloud.genomics.dataflow.pipelines.CountReads \
     --project=YOUR-GOOGLE-CLOUD-PLATFORM-PROJECT-ID \
     --stagingLocation=gs://YOUR-BUCKET/dataflow-staging \

--- a/docs/source/use_cases/annotate_variants/google_genomics_annotation.rst
+++ b/docs/source/use_cases/annotate_variants/google_genomics_annotation.rst
@@ -28,7 +28,7 @@ The following command will use `ClinVar`_ to annotate variants in the `BRCA1`_ g
 
 .. code-block:: shell
 
-  java -cp /PATH/TO/google-genomics-dataflow*.jar \
+  java -cp /PATH/TO/google-genomics-dataflow*runnable.jar \
     com.google.cloud.genomics.dataflow.pipelines.AnnotateVariants \
     --project=YOUR-GOOGLE-CLOUD-PLATFORM-PROJECT-ID \
     --stagingLocation=gs://YOUR-BUCKET/dataflow-staging \

--- a/docs/source/use_cases/compute_identity_by_state/index.rst
+++ b/docs/source/use_cases/compute_identity_by_state/index.rst
@@ -25,7 +25,7 @@ The following command will run Identity-by-State over the BRCA1 region within th
 
 .. code-block:: shell
 
-  java -cp /PATH/TO/google-genomics-dataflow*.jar \
+  java -cp /PATH/TO/google-genomics-dataflow*runnable.jar \
     com.google.cloud.genomics.dataflow.pipelines.IdentityByState \
     --project=YOUR-GOOGLE-CLOUD-PLATFORM-PROJECT-ID \
     --stagingLocation=gs://YOUR-BUCKET/dataflow-staging \

--- a/docs/source/use_cases/compute_principal_coordinate_analysis/1-way-pca.rst
+++ b/docs/source/use_cases/compute_principal_coordinate_analysis/1-way-pca.rst
@@ -32,7 +32,7 @@ The following command will run PCA over the BRCA1 region within the `Platinum Ge
 
 .. code-block:: shell
 
-  java -cp /PATH/TO/google-genomics-dataflow*.jar \
+  java -cp /PATH/TO/google-genomics-dataflow*runnable.jar \
     com.google.cloud.genomics.dataflow.pipelines.VariantSimilarity \
     --project=YOUR-GOOGLE-CLOUD-PLATFORM-PROJECT-ID \
     --stagingLocation=gs://YOUR-BUCKET/dataflow-staging \


### PR DESCRIPTION
Documentation for the fix to https://github.com/googlegenomics/dataflow-java/issues/49 