### PR TITLE
Minor updates.

### DIFF
--- a/docs/source/includes/dataflow_on_gce_setup.rst
+++ b/docs/source/includes/dataflow_on_gce_setup.rst
@@ -23,5 +23,3 @@ If you do not have Java on your local machine, you can set up Java 7 on a `Googl
   sudo apt-get update
   sudo apt-get install --assume-yes openjdk-7-jdk maven
   sudo update-alternatives --config java
-
-*Tip:* Add option ``--noLaunchBrowser`` your dataflow command lines so that the authorization flow prints a URL to be copied instead of launching a web browser.

--- a/docs/source/workshops/bioc-2015.rst
+++ b/docs/source/workshops/bioc-2015.rst
@@ -1,6 +1,8 @@
 BioC 2015: Where Software and Biology Connect
 =============================================
 
+*This workshop was presented at the annual* `Bioconductor Developer's Conference <http://www.bioconductor.org/help/course-materials/2015/BioC2015/>`_.
+
 Google has some pretty amazing big data computational "hammers" that they have been applying to search and video data for a long time.  In this workshop we take those same hammers and apply them to whole genome sequences.
 
 We will work with both the :doc:`/use_cases/discover_public_data/1000_genomes` reads and variants and also the :doc:`/use_cases/discover_public_data/platinum_genomes` gVCF variants.


### PR DESCRIPTION
Now that we are using the OAuth flow from the DataflowSDK, we can remove an obsolete flag.  Dataflow's OAuth flow is hardcoded to not assume a local browser (just like our Spark OAuth flow).
